### PR TITLE
Networking - use refreshed token right away

### DIFF
--- a/lib/networking/dio_api_service.dart
+++ b/lib/networking/dio_api_service.dart
@@ -240,6 +240,7 @@ class DioApiService {
       }
       if (await shouldRefreshToken()) {
         await refreshToken(Dio());
+        bearerToken = await getRefreshedToken();
       }
 
       if (bearerToken != null) {
@@ -438,6 +439,11 @@ class DioApiService {
   /// You can use this to perform a request without affecting the
   /// original [Dio] instance.
   refreshToken(Dio dio) async {}
+
+  /// Fetches refreshed token
+  getRefreshedToken() async {
+    return null;
+  }
 
   /// Check if the users auth token should be refreshed.
   /// This method is called before every request.


### PR DESCRIPTION
When token needs to be refreshed the overridden methods are correctly used, however the request that triggers this check fails, since it was called with the old expired token.

Proposed change:
- add another method that could be overridden that would return a new fresh token (from API, Backpack, Storage, anywhere)
- use this token instead of the old bearer token
- this way it should not be a breaking change